### PR TITLE
sleep between downloading genomes to avoid exceeding api limit

### DIFF
--- a/test/test_min_viral.py
+++ b/test/test_min_viral.py
@@ -31,6 +31,7 @@ along with Kraken.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
+import time
 import sys
 import tempfile
 import argparse
@@ -300,6 +301,7 @@ def create_viral_database(db_inp: str):
                 "curl", "-s", 
                 f"{URL}?db=nuccore&id={accession}&rettype=fasta&retmode=text"
             ]
+            time.sleep(1)
             result = run_command(cmd)
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to download {accession}")


### PR DESCRIPTION
Add sleep between downloading genomes to avoid exceeding api limit. Otherwise it may results a fasta file `viral_genomes.fna` like this
```
CGCTGGGAGAGACCAGAGATCCTGCTGTCTCTACAGCATCATTCCAGGCACAGAACGCCAAAAAATGGAA
TGGTGCTGTTGAATCAACAGGTTCT
{"error":"API rate limit exceeded","api-key":"162.129.251.54","count":"4","limit":"3"}
{"error":"API rate limit exceeded","api-key":"162.129.251.54","count":"4","limit":"3"}
>NC_001417.1 Enterobacterio phage MS2, complete genome
GGGTGGGACCCCTTTCGGGGTCCTGCTCAACTTCCTGTCGAGCTAATGCCATTTTTAATGTCTTTAGCGA
```