### PR TITLE
handling multi-line fasta in KMC

### DIFF
--- a/scripts/build_kraken_db.sh
+++ b/scripts/build_kraken_db.sh
@@ -82,7 +82,7 @@ else
     find library/ -name '*.fna' -print0 | xargs -0 cat > combined_input.fna
     
     # Count k-mers with KMC
-    kmc -k$KRAKEN_KMER_LEN -fa combined_input.fna database_kmc $kmc_temp_dir
+    kmc -k$KRAKEN_KMER_LEN -fm combined_input.fna database_kmc $kmc_temp_dir
     
     # Convert KMC output to Jellyfish format
     "$SCRIPT_DIR/../src/kmc_to_jellyfish" -k $KRAKEN_KMER_LEN database_kmc database.jdb.tmp

--- a/scripts/build_kraken_db.sh
+++ b/scripts/build_kraken_db.sh
@@ -82,7 +82,7 @@ else
     find library/ -name '*.fna' -print0 | xargs -0 cat > combined_input.fna
     
     # Count k-mers with KMC
-    kmc -k$KRAKEN_KMER_LEN -fm combined_input.fna database_kmc $kmc_temp_dir
+    kmc -k$KRAKEN_KMER_LEN -ci1 -fm combined_input.fna database_kmc $kmc_temp_dir
     
     # Convert KMC output to Jellyfish format
     "$SCRIPT_DIR/../src/kmc_to_jellyfish" -k $KRAKEN_KMER_LEN database_kmc database.jdb.tmp

--- a/src/kmc_to_jellyfish.cpp
+++ b/src/kmc_to_jellyfish.cpp
@@ -352,7 +352,8 @@ void create_standard_jellyfish_format(const string& temp_dump) {
 
   // Check if Jellyfish created any files
   string single_file = temp_prefix + "_0";
-  if (access(single_file.c_str(), R_OK) == 0) {
+  string second_file = temp_prefix + "_1";
+  if (access(single_file.c_str(), R_OK) == 0 && access(second_file.c_str(), R_OK) != 0) {
     // Single file created, copy it to the output location
     string copy_cmd = "cp " + single_file + " " + Output_filename;
     ret = system(copy_cmd.c_str());

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -36,6 +36,13 @@ def create_test_fasta(filename, sequences):
             f.write(f">test_{i+1}\n{seq}\n")
 
 
+def create_test_multiline_fasta(filename, sequence):
+    """Create a test FASTA file with given sequences."""
+    with open(filename, 'w') as f:
+        f.write(f">test_0\n")
+        for j in range(0, len(sequence), 80):
+            f.write(f"{sequence[j:j+80]}\n")
+
 def check_required_tools(tools):
     """Check that all required tools are available in PATH."""
     for tool in tools:
@@ -50,7 +57,7 @@ def check_required_files(files):
             raise RuntimeError(f"ERROR: Required file '{file_path}' not found")
 
 
-def create_wide_format_database(sequences, k, temp_dir=None):
+def create_wide_format_database(sequences, k, multiline_1sequence, temp_dir=None):
     """Create a wide format database (k > 31) for testing."""
     if temp_dir is None:
         temp_dir = tempfile.mkdtemp()
@@ -59,7 +66,10 @@ def create_wide_format_database(sequences, k, temp_dir=None):
     
     # Create test FASTA file
     fasta_file = temp_path / "test.fa"
-    create_test_fasta(fasta_file, sequences)
+    if multiline_1sequence:
+        create_test_multiline_fasta(fasta_file, sequences[0])
+    else:
+        create_test_fasta(fasta_file, sequences)
     
     # Build KMC database
     kmc_prefix = temp_path / "kmc_db"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -73,7 +73,7 @@ def create_wide_format_database(sequences, k, multiline_1sequence, temp_dir=None
     
     # Build KMC database
     kmc_prefix = temp_path / "kmc_db"
-    kmc_cmd = f"kmc -k{k} -fa {fasta_file} {kmc_prefix} {temp_path}"
+    kmc_cmd = f"kmc -k{k} -fm {fasta_file} {kmc_prefix} {temp_path}"
     run_command(kmc_cmd)
     
     # Convert to wide format

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -73,7 +73,7 @@ def create_wide_format_database(sequences, k, multiline_1sequence, temp_dir=None
     
     # Build KMC database
     kmc_prefix = temp_path / "kmc_db"
-    kmc_cmd = f"kmc -k{k} -fm {fasta_file} {kmc_prefix} {temp_path}"
+    kmc_cmd = f"kmc -k{k} -ci1 -fm {fasta_file} {kmc_prefix} {temp_path}"
     run_command(kmc_cmd)
     
     # Convert to wide format

--- a/test/test_wide_format.py
+++ b/test/test_wide_format.py
@@ -26,34 +26,47 @@ def test_wide_format_database():
         'TGCATGCATGCATGCATGCATGCATGCATGCA',
         'GATCGATCGATCGATCGATCGATCGATCGATC'
     ]
-    
-    # Create wide format database
-    wide_db = create_wide_format_database(sequences, 32)
-    print(f"Created wide format database: {wide_db}")
-    
-    # Verify the database file exists and has reasonable size
-    if not wide_db.exists():
-        print("FAIL: Wide format database was not created")
-        return False
+
+    long_sequence = ["".join(sequences)*5]
+
+    subtests={'multi-fasta':(sequences, False), 'multi-line-fasta':(long_sequence, True)}
+    results=[]   
+    for subtest_name, (sequences, multiline_1sequence)  in subtests.items():
+
+        # Create wide format database
+        wide_db = create_wide_format_database(sequences, 32, multiline_1sequence)
+        print(f"Created wide format database: {wide_db}")
         
-    db_size = wide_db.stat().st_size
-    if db_size == 0:
-        print("FAIL: Wide format database is empty")
-        return False
+        # Verify the database file exists and has reasonable size
+        if not wide_db.exists():
+            print("FAIL: Wide format database was not created for test {subtest_name}")
+            results.append(False)
+            continue
+            
+        db_size = wide_db.stat().st_size
+        if db_size == 0:
+            print(f"FAIL: Wide format database is empty for test {subtest_name}")
+            results.append(False)
+            continue
+            
+        print(f"PASS: Wide format database created successfully (size: {db_size} bytes) for test {subtest_name}")
         
-    print(f"PASS: Wide format database created successfully (size: {db_size} bytes)")
-    
-    # Test that the database can be read by our test program
-    result = run_test_kraken()
-    
-    if result.returncode == 0:
-        print("PASS: test_kraken program runs successfully")
-        return True
-    else:
-        print(f"FAIL: test_kraken program failed with return code {result.returncode}")
-        if result.stderr:
-            print(f"stderr: {result.stderr}")
-        return False
+        # Test that the database can be read by our test program
+        result = run_test_kraken()
+        
+        if result.returncode == 0:
+            print(f"PASS: test_kraken program runs successfully for test {subtest_name}")
+            results.append(True)
+            
+        else:
+            print(f"FAIL: test_kraken program failed with return code {result.returncode} for test {subtest_name}")
+            if result.stderr:
+                print(f"stderr: {result.stderr}")
+            results.append(False)
+            continue
+
+    return all(results)
+
 
 def main():
     print("Wide Format Database Test")


### PR DESCRIPTION
KMC can only work multi-line fast if is fed with -fm instead of -fa. See this [KMC github issue](https://github.com/refresh-bio/KMC/issues/214). I updated the script in both `scripts/build_kraken_db.sh` and `test/test_utils.py`. I also added a new test in `test/test_wide_format.py` for this scenario. 
